### PR TITLE
chore: add missing additional nodes required

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Requirements:
 2. Node-Red Addon, additional nodes
    - node-red-contrib-crypto-js
    - node-red-contrib-random-string
+   - node-red-contrib-credentials
 4. MQTT
 5. Rainpoint Application (instead of Homegar):
 


### PR DESCRIPTION
I tried to deploy your flow with fresh node-red and found that my node-red not know type credentials, so i need to add `node-red-contrib-credentials`.